### PR TITLE
16 setup idempotent

### DIFF
--- a/api/src/server/mod.rs
+++ b/api/src/server/mod.rs
@@ -38,6 +38,7 @@ pub async fn start<T: ToSocketAddrs + Debug>(bind: T, database_args: pg::Args<'_
         let skip_paths = vec![
             "/register".into(),
             "/authenticate".into(),
+            "/public_keys".into(),
         ];
 
         let jwt_middleware = Jwt::new(authority_service.clone(), skip_paths);

--- a/lib/src/realms.rs
+++ b/lib/src/realms.rs
@@ -48,6 +48,18 @@ impl RealmService {
         Ok(realms)
     }
 
+    pub async fn by_name(&self, name: String) -> Result<Realm> {
+        let result = sqlx::query_as::<_, Realm>(r#"
+            SELECT * FROM realms
+            WHERE name = $1
+        "#)
+            .bind(name)
+            .fetch_one(&self.pool)
+            .await?;
+
+        Ok(result)
+    }
+
     pub async fn by_id(&self, id: Uuid) -> Result<Realm> {
         let result = sqlx::query_as::<_, Realm>(r#"
             SELECT * FROM realms


### PR DESCRIPTION
- Adds `by_name` method to realm service
- checks to see if realm exists (by name) before seeding
- adds /public_keys/* to the JWT middleware permit list